### PR TITLE
fix" MSB4120: definition within target references itself

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,15 +20,16 @@ Works around [symbols not being copied from references](https://github.com/dotne
         AfterTargets="ResolveAssemblyReferences"
         Condition="@(ReferenceCopyLocalPaths) != ''">
   <ItemGroup>
-    <ReferenceCopyLocalPaths
+    <PdbFilesToAdd
             Include="%(ReferenceCopyLocalPaths.RelativeDir)%(ReferenceCopyLocalPaths.Filename).pdb"
             DestinationSubDirectory="%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
-    <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
-                             Condition="!Exists('%(FullPath)')" />
+    <PdbFilesToAdd Remove="@(PdbFilesToAdd)"
+                   Condition="!Exists('%(FullPath)')" />
+    <ReferenceCopyLocalPaths Include="@(PdbFilesToAdd)" />
   </ItemGroup>
 </Target>
 ```
-<sup><a href='/src/Cymbal/build/Cymbal.targets#L19-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-includesymbolfromreferences' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Cymbal/build/Cymbal.targets#L19-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-includesymbolfromreferences' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 This is done at Build time.

--- a/src/Cymbal/build/Cymbal.targets
+++ b/src/Cymbal/build/Cymbal.targets
@@ -5,28 +5,29 @@
   </PropertyGroup>
 
   <UsingTask
-    TaskName="CymbalTask"
-    AssemblyFile="$(CymbalAssembly)" />
+          TaskName="CymbalTask"
+          AssemblyFile="$(CymbalAssembly)" />
   <Target
-    Name="CymbalTarget"
-    AfterTargets="Publish" >
+          Name="CymbalTarget"
+          AfterTargets="Publish" >
     <CymbalTask PublishDirectory="$(PublishDir)"
                 CacheDirectory="$(CymbalCacheDirectory)"
                 SymbolServers="@(SymbolServer)"/>
     <Message Text="@(TargetOutputs,'%0a')"
              Importance="high" />
   </Target>
-<!-- begin-snippet: IncludeSymbolFromReferences-->
+  <!-- begin-snippet: IncludeSymbolFromReferences-->
   <Target Name="IncludeSymbolFromReferences"
           AfterTargets="ResolveAssemblyReferences"
           Condition="@(ReferenceCopyLocalPaths) != ''">
     <ItemGroup>
-      <ReferenceCopyLocalPaths
+      <PdbFilesToAdd
               Include="%(ReferenceCopyLocalPaths.RelativeDir)%(ReferenceCopyLocalPaths.Filename).pdb"
               DestinationSubDirectory="%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
-                               Condition="!Exists('%(FullPath)')" />
+      <PdbFilesToAdd Remove="@(PdbFilesToAdd)"
+                     Condition="!Exists('%(FullPath)')" />
+      <ReferenceCopyLocalPaths Include="@(PdbFilesToAdd)" />
     </ItemGroup>
   </Target>
-<!-- end-snippet -->
+  <!-- end-snippet -->
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <SolutionDir>$(ProjectDir)..\</SolutionDir>
     <SignAssembly>false</SignAssembly>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Tests/Tests.RunTask_environmentCache=False_propertyCache=False.DotNet.verified.txt
+++ b/src/Tests/Tests.RunTask_environmentCache=False_propertyCache=False.DotNet.verified.txt
@@ -1,9 +1,7 @@
 ﻿{
   buildOutput:
      1>Project "{SolutionDirectory}SampleApp/SampleApp.csproj" on node 1 (Publish target(s)).
-     1>IncludeSymbolFromReferences:
-       {SolutionDirectory}Cymbal/build/Cymbal.targets(26,14): message : MSB4120: Item 'ReferenceCopyLocalPaths' definition within target references itself via (qualified or unqualified) metadatum 'DestinationSubDirectory'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref [{SolutionDirectory}SampleApp/SampleApp.csproj]
-       PrepareForPublish:
+     1>PrepareForPublish:
        _CopyResolvedFilesToPublishPreserveNewest:
        _CopyResolvedFilesToPublishAlways:
        Publish:

--- a/src/Tests/Tests.RunTask_environmentCache=False_propertyCache=True.DotNet.verified.txt
+++ b/src/Tests/Tests.RunTask_environmentCache=False_propertyCache=True.DotNet.verified.txt
@@ -1,9 +1,7 @@
 ﻿{
   buildOutput:
      1>Project "{SolutionDirectory}SampleApp/SampleApp.csproj" on node 1 (Publish target(s)).
-     1>IncludeSymbolFromReferences:
-       {SolutionDirectory}Cymbal/build/Cymbal.targets(26,14): message : MSB4120: Item 'ReferenceCopyLocalPaths' definition within target references itself via (qualified or unqualified) metadatum 'DestinationSubDirectory'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref [{SolutionDirectory}SampleApp/SampleApp.csproj]
-       PrepareForPublish:
+     1>PrepareForPublish:
        _CopyResolvedFilesToPublishPreserveNewest:
        _CopyResolvedFilesToPublishAlways:
        Publish:

--- a/src/Tests/Tests.RunTask_environmentCache=True_propertyCache=False.DotNet.verified.txt
+++ b/src/Tests/Tests.RunTask_environmentCache=True_propertyCache=False.DotNet.verified.txt
@@ -1,9 +1,7 @@
 ﻿{
   buildOutput:
      1>Project "{SolutionDirectory}SampleApp/SampleApp.csproj" on node 1 (Publish target(s)).
-     1>IncludeSymbolFromReferences:
-       {SolutionDirectory}Cymbal/build/Cymbal.targets(26,14): message : MSB4120: Item 'ReferenceCopyLocalPaths' definition within target references itself via (qualified or unqualified) metadatum 'DestinationSubDirectory'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref [{SolutionDirectory}SampleApp/SampleApp.csproj]
-       PrepareForPublish:
+     1>PrepareForPublish:
        _CopyResolvedFilesToPublishPreserveNewest:
        _CopyResolvedFilesToPublishAlways:
        Publish:

--- a/src/Tests/Tests.RunTask_environmentCache=True_propertyCache=True.DotNet.verified.txt
+++ b/src/Tests/Tests.RunTask_environmentCache=True_propertyCache=True.DotNet.verified.txt
@@ -1,9 +1,7 @@
 ﻿{
   buildOutput:
      1>Project "{SolutionDirectory}SampleApp/SampleApp.csproj" on node 1 (Publish target(s)).
-     1>IncludeSymbolFromReferences:
-       {SolutionDirectory}Cymbal/build/Cymbal.targets(26,14): message : MSB4120: Item 'ReferenceCopyLocalPaths' definition within target references itself via (qualified or unqualified) metadatum 'DestinationSubDirectory'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref [{SolutionDirectory}SampleApp/SampleApp.csproj]
-       PrepareForPublish:
+     1>PrepareForPublish:
        _CopyResolvedFilesToPublishPreserveNewest:
        _CopyResolvedFilesToPublishAlways:
        Publish:

--- a/src/Tests/Tests.Should_Parse_SymbolServer.verified.txt
+++ b/src/Tests/Tests.Should_Parse_SymbolServer.verified.txt
@@ -1,9 +1,7 @@
 ﻿{
   buildOutput:
      1>Project "{SolutionDirectory}SampleWithSymbolServer/SampleWithSymbolServer.csproj" on node 1 (Publish target(s)).
-     1>IncludeSymbolFromReferences:
-       {SolutionDirectory}Cymbal/build/Cymbal.targets(26,14): message : MSB4120: Item 'ReferenceCopyLocalPaths' definition within target references itself via (qualified or unqualified) metadatum 'DestinationSubDirectory'. This can lead to unintended expansion and cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref [{SolutionDirectory}SampleWithSymbolServer/SampleWithSymbolServer.csproj]
-       PrepareForPublish:
+     1>PrepareForPublish:
        _CopyResolvedFilesToPublishPreserveNewest:
        _CopyResolvedFilesToPublishAlways:
        Publish:


### PR DESCRIPTION
```
Cymbal.targets(26,14): message : MSB4120: Item 'ReferenceCopyLocalPaths' definition within target references itself via (qualified or unqualified) metadatum 'DestinationSubDirectory'.
This can lead to unintended expansion and cross-applying of pre-existing items.
More info: https://aka.ms/msbuild/metadata-self-ref [C:\Code\MinisterialProgramApi\src\Api\Api.csproj]
```
