### PR TITLE
Set SuppressDependenciesWhenPacking

### DIFF
--- a/src/Cymbal/Cymbal.csproj
+++ b/src/Cymbal/Cymbal.csproj
@@ -1,4 +1,4 @@
-
+﻿
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <NoWarn>NU5118</NoWarn>
@@ -7,6 +7,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild Condition="$(Configuration) == 'Release'">true</GeneratePackageOnBuild>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Description>Enable line numbers for exceptions in a deployed app via downloading and bundling symbols during a dotnet publish.</Description>


### PR DESCRIPTION
Just a tiny detail. It will suppress the `dependencies` section in the generated nuspec file.